### PR TITLE
use greedy match and fix 'title' part in reference

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -464,7 +464,7 @@ var inline = {
 };
 
 inline._inside = /(?:\[[^\]]*\]|[^\[\]]|\](?=[^\[]*\]))*/;
-inline._href = /\s*<?([\s\S]*?)>?(?:\s+['"]([\s\S]*?)['"])?\s*/;
+inline._href = /\s*<?([\s\S]*)>?\s+(?:['"]([\s\S]*)['"])?\s*/;
 
 inline.link = replace(inline.link)
   ('inside', inline._inside)


### PR DESCRIPTION
1.  use greedy match to include right braces of the url: 
2. extract title part from the braces

tested with [link](http://a.link.com/aword_(SOMEWORD) "title")